### PR TITLE
Reduced call concurrency

### DIFF
--- a/miniwdl_aws.cfg
+++ b/miniwdl_aws.cfg
@@ -14,7 +14,7 @@
 container_backend = aws_batch_job
 # One `miniwdl run` process will be able to orchestrate this many concurrent AWS Batch jobs. (This
 # controls the size of a thread pool, so setting it too high tends to be counterproductive.)
-call_concurrency = 100
+call_concurrency = 80
 # Reduced concurrency limit for URI download jobs; since these are typically S3 downloads that are
 # very fast, running many concurrently is likely to overstress EFS.
 download_concurrency = 10


### PR DESCRIPTION
Reduce call concurrency to avoid issues with too many jobs connecting to EFS.