### PR TITLE
add ability to request gpu resources

### DIFF
--- a/miniwdl_aws/batch_job.py
+++ b/miniwdl_aws/batch_job.py
@@ -305,15 +305,22 @@ class BatchJob(WDL.runtime.task_container.TaskContainer):
             commands.append("sync ../stdout.txt ../stderr.txt")
         commands.append("exit $exit_code")
 
+        resource_requirements = [
+            {"type": "VCPU", "value": str(vcpu)},
+            {"type": "MEMORY", "value": str(memory_mbytes)},
+        ]
+
+        if self.runtime_values.get("gpu", False):
+            resource_requirements += [
+                {"type": "GPU", "value": "1"}
+            ]
+
         container_properties = {
             "image": image_tag,
             "volumes": volumes,
             "mountPoints": mount_points,
             "command": ["/bin/bash", "-ec", "\n".join(commands)],
-            "resourceRequirements": [
-                {"type": "VCPU", "value": str(vcpu)},
-                {"type": "MEMORY", "value": str(memory_mbytes)},
-            ],
+            "resourceRequirements": resource_requirements,
             "privileged": self.runtime_values.get("privileged", False),
         }
 

--- a/miniwdl_aws/batch_job.py
+++ b/miniwdl_aws/batch_job.py
@@ -311,9 +311,7 @@ class BatchJob(WDL.runtime.task_container.TaskContainer):
         ]
 
         if self.runtime_values.get("gpu", False):
-            resource_requirements += [
-                {"type": "GPU", "value": "1"}
-            ]
+            resource_requirements += [{"type": "GPU", "value": "1"}]
 
         container_properties = {
             "image": image_tag,


### PR DESCRIPTION
For WDL tasks that specify:

```wdl
runtime {
  gpu: true
}
```

Add the appropriate `resourceRequirements` to the corresponding AWS Batch Job Definition