### PR TITLE
CloudFormation template for AWS infrastructure deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,17 @@
+# Fork improvements
+
+## CloudFormation template for cloud setup
+Deployment scropt for **miniwdl-aws cloud**, re[placement Terraform-based script [**miniwdl-aws-terraform**](https://github.com/miniwdl-ext/miniwdl-aws-terraform)]
+
+
+Deployment CLI:
+```
+ aws cloudformation deploy --template-file cfn-miniwdl.yaml --stack-name MiniWDL --capabilities CAPABILITY_NAMED_IAM --parameter-overrides  Owner=somebody@pheno.ai
+ aws cloudformation describe-stacks --stack-name MiniWDL
+```
+
+
+---
 # miniwdl AWS plugin
 
 **Extends [miniwdl](https://github.com/chanzuckerberg/miniwdl) to run workflows on [AWS Batch](https://aws.amazon.com/batch/) and [EFS](https://aws.amazon.com/efs/)**

--- a/README.md
+++ b/README.md
@@ -4,12 +4,22 @@
 Deployment scropt for **miniwdl-aws cloud**, re[placement Terraform-based script [**miniwdl-aws-terraform**](https://github.com/miniwdl-ext/miniwdl-aws-terraform)]
 
 
-Deployment CLI:
+Deployment CLI (replace
+  - somebody@someemail.com with your username/email for identification of allocated resources
+  - miniwdl-bucket with desired name for S3 buckets for outputs. miniwdl-bucket is default
+):
 ```
- aws cloudformation deploy --template-file cfn-miniwdl.yaml --stack-name MiniWDL --capabilities CAPABILITY_NAMED_IAM --parameter-overrides  Owner=somebody@pheno.ai
- aws cloudformation describe-stacks --stack-name MiniWDL
+aws s3 mb s3://miniwdl-bucket
+aws cloudformation deploy --template-file cfn-miniwdl.yaml \
+    --stack-name MiniWDL --capabilities CAPABILITY_NAMED_IAM \
+    --parameter-overrides  S3UploadBucket=miniwdl-bucket Owner=somebody@someemail.com
+aws cloudformation describe-stacks --stack-name MiniWDL
 ```
 
+to test your setup, run
+```
+miniwdl-aws-submit --self-test --follow --workflow-queue miniwdl-workflow 
+```
 
 ---
 # miniwdl AWS plugin

--- a/cfn-miniwdl.yaml
+++ b/cfn-miniwdl.yaml
@@ -1,0 +1,398 @@
+AWSTemplateFormatVersion: 2010-09-09
+
+Description: >  
+  provision AWS infrastructure for [miniwdl-aws](https://github.com/miniwdl-ext/miniwdl-aws) 
+  -- including a VPC, EFS file system, Batch queues, and IAM roles.
+
+Parameters:
+  Owner:
+    Description: Owner tag applied to all resources, e.g. your username/email
+    Type: String
+
+  Environment:
+    Description: Environment tag applied to all resources, and used in some resource names
+    Type: String
+    Default: phenowdl
+
+  S3UploadBucket:
+    Description: S3 bucket name for automatic upload of workflow outputs with `miniwdl-aws-submit --s3upload`
+    Type: String
+    Default: phenowdl-bucket
+    AllowedPattern: "((?=^.{3,63}$)(?!^(\\d+\\.)+\\d+$)(^(([a-z0-9]|[a-z0-9][a-z0-9\\-]*[a-z0-9])\\.)*([a-z0-9]|[a-z0-9][a-z0-9\\-]*[a-z0-9])$)|(^.{0}$))"
+    ConstraintDescription: "Must respect AWS naming conventions"
+
+  MaxVCPUTask:
+    Description: Maximum vCPUs for task compute environment
+    Type: Number
+    Default: 256
+
+  MaxVCPUWorkflow:
+    Description: Maximum vCPUs for workflow compute environment
+    Type: Number
+    Default: 16
+
+Resources:
+#######################
+# Networking
+# borrowing from https://github.com/awslabs/genomics-secondary-analysis-using-aws-step-functions-and-aws-batch
+#######################
+  VPC:
+    Type: AWS::EC2::VPC
+    Properties:
+      CidrBlock: 10.0.0.0/16
+      EnableDnsSupport: true
+      EnableDnsHostnames: true
+      InstanceTenancy: default
+      Tags:
+        - Key: Name
+          Value: !Sub ${Environment}-vpc
+        - Key: Environment
+          Value: !Sub ${Environment}
+        - Key: Owner
+          Value: !Sub ${Owner}
+
+  InternetGateway:
+    Type: AWS::EC2::InternetGateway
+    Properties:
+      Tags:
+        - Key: Name
+          Value: !Sub ${Environment}-igw
+        - Key: Environment
+          Value: !Sub ${Environment}
+        - Key: Owner
+          Value: !Sub ${Owner}
+
+  VPCGatewayAttachment:
+    Type: AWS::EC2::VPCGatewayAttachment
+    Properties:
+      VpcId: !Ref VPC
+      InternetGatewayId: !Ref InternetGateway
+
+# For simplicity, one public subnet per availability zone. Private subnet(s) with NAT could work.
+  SubnetPublic0:
+    Type: AWS::EC2::Subnet
+    Properties:
+      VpcId: !Ref VPC
+      CidrBlock: !Select [ 0, !Cidr [ !GetAtt VPC.CidrBlock, 3, 13]]
+      #MapPublicIpOnLaunch: true
+      AvailabilityZone:
+        Fn::Select:
+          - 0
+          - Fn::GetAZs: ""
+      Tags:
+        - Key: Name
+          Value: !Sub ${Environment}-Public-0
+        - Key: Environment
+          Value: !Sub ${Environment}
+        - Key: Owner
+          Value: !Sub ${Owner}
+
+  SubnetPublic1:
+    Type: AWS::EC2::Subnet
+    Properties:
+      VpcId: !Ref VPC
+      CidrBlock: !Select [ 1, !Cidr [ !GetAtt VPC.CidrBlock, 3, 13]]
+      #MapPublicIpOnLaunch: true
+      AvailabilityZone:
+        Fn::Select:
+          - 1
+          - Fn::GetAZs: ""
+      Tags:
+        - Key: Name
+          Value: !Sub ${Environment}-Public-1
+        - Key: Environment
+          Value: !Sub ${Environment}
+        - Key: Owner
+          Value: !Sub ${Owner}
+
+  SubnetPublic2:
+    Type: AWS::EC2::Subnet
+    Properties:
+      VpcId: !Ref VPC
+      CidrBlock: !Select [ 2, !Cidr [ !GetAtt VPC.CidrBlock, 3, 13]]
+      #MapPublicIpOnLaunch: true
+      AvailabilityZone:
+        Fn::Select:
+          - 2
+          - Fn::GetAZs: ""
+      Tags:
+        - Key: Name
+          Value: !Sub ${Environment}-Public-2
+        - Key: Environment
+          Value: !Sub ${Environment}
+        - Key: Owner
+          Value: !Sub ${Owner}
+
+  PublicRouteTable:
+    Type: AWS::EC2::RouteTable
+    Properties:
+      VpcId: !Ref VPC
+      Tags:
+        - Key: Name
+          Value: !Sub ${Environment}-rtb
+        - Key: Environment
+          Value: !Sub ${Environment}
+        - Key: Owner
+          Value: !Sub ${Owner}
+
+  PublicRoute:
+    Type: AWS::EC2::Route
+    DependsOn: VPCGatewayAttachment
+    Properties:
+      DestinationCidrBlock: 0.0.0.0/0
+      GatewayId: !Ref InternetGateway
+      RouteTableId: !Ref PublicRouteTable
+  SubnetPublic0RouteTableAssociation:
+    Type: AWS::EC2::SubnetRouteTableAssociation
+    Properties:
+      RouteTableId: !Ref PublicRouteTable
+      SubnetId: !Ref SubnetPublic0
+  SubnetPublic1RouteTableAssociation:
+    Type: AWS::EC2::SubnetRouteTableAssociation
+    Properties:
+      RouteTableId: !Ref PublicRouteTable
+      SubnetId: !Ref SubnetPublic1
+  SubnetPublic2RouteTableAssociation:
+    Type: AWS::EC2::SubnetRouteTableAssociation
+    Properties:
+      RouteTableId: !Ref PublicRouteTable
+      SubnetId: !Ref SubnetPublic2
+
+  # Use a VPC Gateway Endpoint for S3 so that requests for data do not route over the public internet
+  S3VpcEndpoint:
+    Type: "AWS::EC2::VPCEndpoint"
+    Properties:
+      RouteTableIds:
+        - !Ref PublicRouteTable
+      ServiceName: !Sub com.amazonaws.${AWS::Region}.s3 #required
+      VpcId: !Ref VPC #required
+
+# Umbrella security group for Batch compute environments & EFS mount targets, allowing any traffic
+# within the VPC and outbound (but not inbound) Internet. The ingress could be locked down to only
+# make the EFS mount targets (TCP 2049) reachable from the Batch compute environments.
+  SecurityGroup:
+    Type: AWS::EC2::SecurityGroup
+    Properties:
+      GroupDescription: Security group for AWS Batch Launched Instances.
+      VpcId: !Ref VPC
+      SecurityGroupEgress:
+        - Description: Allow all outbound traffic for updates.
+          IpProtocol: "-1"
+          CidrIp: 0.0.0.0/0
+    Metadata:
+      cfn_nag:
+        rules_to_suppress:
+          - id: W40
+            reason: Allow all outbound traffic for updates.
+          - id: W5
+            reason: Allow all outbound traffic for updates.
+          - id: W42
+            reason: Allow self-ingress on all ports for inter-node communication
+  
+  # this ingress rule is needed if you have tightly coupled multi-node workloads
+  # or if you are using a parallel filesystem
+  SecurityGroupSelfIngress:
+    Type: "AWS::EC2::SecurityGroupIngress"
+    Properties:
+      Description: Allow instances in the same security group to communicate
+      IpProtocol: "-1" #required
+      GroupId: !Ref SecurityGroup
+      SourceSecurityGroupId: !Ref SecurityGroup
+    Metadata:
+      cfn_nag:
+        rules_to_suppress:
+          - id: W42
+            reason: Allow self-ingress on all ports for inter-node communication
+#######################
+# EFS
+# borrowed from https://github.com/aws-samples/aws-genomics-workflows
+#######################
+  SharedDataFileSystem:
+    Type: AWS::EFS::FileSystem
+    Properties:
+      PerformanceMode: maxIO #generalPurpose
+      Encrypted: true
+      FileSystemTags:
+        - Key: Name
+          Value: !Sub ${Environment}-efs
+        - Key: Environment
+          Value: !Sub ${Environment}
+        - Key: Owner
+          Value: !Sub ${Owner}
+
+  MountTargetSubnet0:
+    Type: AWS::EFS::MountTarget
+    Properties:
+      FileSystemId: !Ref SharedDataFileSystem
+      SubnetId: !Ref SubnetPublic0
+      SecurityGroups: 
+      - !Ref SecurityGroup
+  MountTargetSubnet1:
+    Type: AWS::EFS::MountTarget
+    Properties:
+      FileSystemId: !Ref SharedDataFileSystem
+      SubnetId: !Ref SubnetPublic1
+      SecurityGroups: 
+      - !Ref SecurityGroup
+  MountTargetSubnet2:
+    Type: AWS::EFS::MountTarget
+    Properties:
+      FileSystemId: !Ref SharedDataFileSystem
+      SubnetId: !Ref SubnetPublic2
+      SecurityGroups: 
+      - !Ref SecurityGroup
+
+#######################
+# IAM roles
+#######################
+# For Batch EC2 worker instances running WDL tasks
+  IAMRoleTask:
+    Type: "AWS::IAM::Role"
+    Properties:
+      Path: "/"
+      RoleName: !Sub ${Environment}-task
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service:
+                - ec2.amazonaws.com
+            Action:
+              - 'sts:AssumeRole'
+      MaxSessionDuration: 3600
+      ManagedPolicyArns: 
+      - "arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryReadOnly"
+      - "arn:aws:iam::aws:policy/AmazonS3ReadOnlyAccess"
+      - "arn:aws:iam::aws:policy/service-role/AmazonEC2ContainerServiceforEC2Role"
+      - "arn:aws:iam::aws:policy/AmazonElasticFileSystemClientReadWriteAccess"
+      Tags: 
+        - Key: Environment
+          Value: !Sub ${Environment}
+        - Key: Owner
+          Value: !Sub ${Owner}
+# For Batch Fargate tasks running miniwdl itself
+# This role needs to be set with the Batch job definition, not as part of the compute environment;
+# miniwdl-aws-submit detects it from the WorkflowEngineRoleArn tag on the workflow job queue, set
+# above.
+  IAMRoleWorkflow:
+    Type: "AWS::IAM::Role"
+    Properties:
+      Path: "/"
+      RoleName: !Sub ${Environment}-workflow
+      AssumeRolePolicyDocument: 
+        Version: '2012-10-17'
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service:
+                - ecs-tasks.amazonaws.com
+            Action:
+              - 'sts:AssumeRole'
+      MaxSessionDuration: 3600
+      ManagedPolicyArns: 
+      - "arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryReadOnly"
+      - "arn:aws:iam::aws:policy/AmazonS3ReadOnlyAccess"
+      - "arn:aws:iam::aws:policy/AWSBatchFullAccess"
+      - "arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy"
+      - "arn:aws:iam::aws:policy/AmazonElasticFileSystemClientFullAccess"
+      Tags: 
+        - Key: Environment
+          Value: !Sub ${Environment}
+        - Key: Owner
+          Value: !Sub ${Owner}
+# workflow needs permissions for --s3upload, attach it as inline policy
+  IAMPolicy:
+    Type: "AWS::IAM::Policy"
+    Properties:
+      PolicyDocument: 
+        Version: '2012-10-17'
+        Statement:
+          - Action:
+              - s3:ListBucket
+            Effect: Allow
+            Resource:
+              - !Sub arn:aws:s3:::${S3UploadBucket}
+          - Action:
+              - s3:GetObject
+              - s3:PutObject
+            Effect: Allow
+            Resource:
+              - !Sub arn:aws:s3:::${S3UploadBucket}/*
+      Roles: 
+        - !Ref IAMRoleWorkflow
+      PolicyName: !Sub "${IAMRoleWorkflow}-s3upload"
+
+# Boilerplate roles
+  IAMRoleBatch:
+    Type: "AWS::IAM::Role"
+    Properties:
+      Path: "/"
+      RoleName: !Sub ${Environment}-batch
+      AssumeRolePolicyDocument: 
+        Version: '2012-10-17'
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service:
+                - batch.amazonaws.com
+            Action:
+              - 'sts:AssumeRole'
+      MaxSessionDuration: 3600
+      ManagedPolicyArns: 
+      - "arn:aws:iam::aws:policy/service-role/AWSBatchServiceRole"
+      Tags: 
+        - Key: Environment
+          Value: !Sub ${Environment}
+        - Key: Owner
+          Value: !Sub ${Owner}
+
+  IAMRoleSpot:
+    Type: "AWS::IAM::Role"
+    Properties:
+      Path: "/"
+      RoleName: !Sub ${Environment}-spot
+      AssumeRolePolicyDocument: 
+        Version: '2012-10-17'
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service:
+                - spotfleet.amazonaws.com
+            Action:
+              - 'sts:AssumeRole'
+      MaxSessionDuration: 3600
+      ManagedPolicyArns: 
+      - "arn:aws:iam::aws:policy/service-role/AmazonEC2SpotFleetTaggingRole"
+      Tags: 
+        - Key: Environment
+          Value: !Sub ${Environment}
+        - Key: Owner
+          Value: !Sub ${Owner}
+
+# The following service-linked roles can be created only once per account; As oposite to TerraForm, 
+# CloudFormation is Ok with trying to create it again as long as description stil the same 
+  SpotSLR:
+    Type: 'AWS::IAM::ServiceLinkedRole'
+    Properties:
+      AWSServiceName: spot.amazonaws.com
+      Description: Default EC2 Spot Service Linked Role
+  SpotFleeSLR:
+    Type: 'AWS::IAM::ServiceLinkedRole'
+    Properties:
+      AWSServiceName: spotfleet.amazonaws.com
+      Description: Default EC2 Spot Fleet Service Linked Role
+
+
+Outputs:
+  VpcId:
+    Value: !Ref VPC
+  PublicSubNetIds:
+    Value: !Sub ${SubnetPublic0},${SubnetPublic1},${SubnetPublic0}
+  InternetGatewayId:
+    Value: !Ref InternetGateway
+  SecurityGroupId:
+    Value: !Sub ${SecurityGroup}
+  EfsId:
+    Value: !Ref SharedDataFileSystem
+    Description: EFS ID

--- a/cfn-miniwdl.yaml
+++ b/cfn-miniwdl.yaml
@@ -31,6 +31,11 @@ Parameters:
     Type: Number
     Default: 16
 
+  BatchSpotBidPercentage:
+    Type: Number
+    Description: The maximum percentage that an EC2 Spot Instance price can be when compared with the On-Demand price for that instance type before instances are launched.
+    Default: 100
+
 Resources:
 #######################
 # Networking
@@ -242,6 +247,16 @@ Resources:
       SecurityGroups: 
       - !Ref SecurityGroup
 
+  AccessPoint:
+      Type: 'AWS::EFS::AccessPoint'
+      Properties:
+        FileSystemId: !Ref SharedDataFileSystem
+        PosixUser:
+          Uid: 0
+          Gid: 0
+        RootDirectory:
+          Path: /
+        
 #######################
 # IAM roles
 #######################
@@ -383,16 +398,172 @@ Resources:
       AWSServiceName: spotfleet.amazonaws.com
       Description: Default EC2 Spot Fleet Service Linked Role
 
+#######################
+# Batch
+#######################
+  IAMRoleTaskProfile:
+    Type: AWS::IAM::InstanceProfile
+    Properties:
+      InstanceProfileName: !Sub ${Environment}-task
+      Path: "/"
+      Roles:
+        - Ref: IAMRoleTask
 
+  LaunchTemplateTask:
+    Type: AWS::EC2::LaunchTemplate
+    Properties:
+      LaunchTemplateName: !Sub ${Environment}-task
+      LaunchTemplateData:
+        IamInstanceProfile:
+          Name: !Sub ${Environment}-task
+        UserData:
+          Fn::Base64: |
+            MIME-Version: 1.0
+            Content-Type: multipart/mixed; boundary="==MYBOUNDARY=="
+
+            --==MYBOUNDARY==
+            Content-Type: text/x-shellscript; charset="us-ascii"
+
+            #!/bin/bash
+            # To run on first boot of an EC2 instance with NVMe instance storage volumes:
+            # 1) Assembles them into a RAID0 array, formats with XFS, and mounts to /mnt/scratch
+            # 2) Replaces /var/lib/docker with a symlink to /mnt/scratch/docker so that docker images and
+            #    container file systems use this high-performance scratch space. (restarts docker)
+            # The configuration persists through reboots (but not instance stop).
+            # logs go to /var/log/cloud-init-output.log
+            # refs:
+            # https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ssd-instance-store.html
+            # https://github.com/kislyuk/aegea/blob/master/aegea/rootfs.skel/usr/bin/aegea-format-ephemeral-storage
+
+            set -euxo pipefail
+            shopt -s nullglob
+
+
+            devices=(/dev/xvd[b-m] /dev/disk/by-id/nvme-Amazon_EC2_NVMe_Instance_Storage_AWS?????????????????)
+            num_devices="${#devices[@]}"
+            if (( num_devices > 0 )) && ! grep /dev/md0 <(df); then
+                mdadm --create /dev/md0 --force --auto=yes --level=0 --chunk=256 --raid-devices=${num_devices} ${devices[@]}
+                mkfs.xfs -f /dev/md0
+                mkdir -p /mnt/scratch
+                mount -o defaults,noatime,largeio,logbsize=256k -t xfs /dev/md0 /mnt/scratch
+                echo UUID=$(blkid -s UUID -o value /dev/md0) /mnt/scratch xfs defaults,noatime,largeio,logbsize=256k 0 2 >> /etc/fstab
+                update-initramfs -u
+            fi
+            mkdir -p /mnt/scratch/tmp
+
+
+            systemctl stop docker || true
+            if [ -d /var/lib/docker ] && [ ! -L /var/lib/docker ]; then
+                mv /var/lib/docker /mnt/scratch
+            fi
+            mkdir -p /mnt/scratch/docker
+            ln -s /mnt/scratch/docker /var/lib/docker
+            systemctl restart docker || true
+            --==MYBOUNDARY==--
+
+  ComputeEnvironmentTask:
+    Type: AWS::Batch::ComputeEnvironment
+    Properties:
+      ComputeEnvironmentName: !Sub ${Environment}-task
+      ServiceRole: !GetAtt IAMRoleBatch.Arn
+      Type: MANAGED
+      State: ENABLED
+      ComputeResources:
+        Type: SPOT
+        InstanceTypes: 
+          - r5d
+          - m5d
+          - c5d
+        AllocationStrategy: SPOT_CAPACITY_OPTIMIZED
+        # Set the Spot price to 75% of on-demand price
+        # This is the maximum price for spot instances that Batch will launch.
+        # Lowering this puts a limit on the spot capacity that Batch has available.
+        # Spot instances are terminated when on-demand capacity is needed, regardless of the price set.
+        BidPercentage: !Ref BatchSpotBidPercentage 
+        MinvCpus: 0
+        MaxvCpus: !Sub ${MaxVCPUTask} 
+        Subnets:
+          - !Ref SubnetPublic0
+          - !Ref SubnetPublic1
+          - !Ref SubnetPublic2
+        SecurityGroupIds:
+          - !Ref SecurityGroup
+        SpotIamFleetRole: !GetAtt IAMRoleSpot.Arn
+        InstanceRole: !GetAtt IAMRoleTaskProfile.Arn  
+        LaunchTemplate:
+          LaunchTemplateId: !Ref LaunchTemplateTask     
+      Tags: 
+        Environment: !Sub ${Environment}
+        Owner: !Sub ${Owner} 
+
+  ComputeEnvironmentWorkflow:
+    Type: AWS::Batch::ComputeEnvironment
+    Properties:
+      ComputeEnvironmentName: !Sub ${Environment}-workflow
+      ServiceRole: !GetAtt IAMRoleBatch.Arn
+      Type: MANAGED
+      State: ENABLED
+      ComputeResources:
+        Type: FARGATE
+        MaxvCpus: !Sub ${MaxVCPUWorkflow} 
+        Subnets:
+          - !Ref SubnetPublic0
+          - !Ref SubnetPublic1
+          - !Ref SubnetPublic2
+        SecurityGroupIds:
+          - !Ref SecurityGroup
+      Tags: 
+        Environment: !Sub ${Environment}
+        Owner: !Sub ${Owner} 
+
+  BatchJobQueueTask:
+    Type: AWS::Batch::JobQueue
+    Properties:
+      JobQueueName: !Sub ${Environment}-task
+      Priority: 1
+      State: ENABLED
+      ComputeEnvironmentOrder:
+        - Order: 0
+          ComputeEnvironment: !Ref ComputeEnvironmentTask
+      Tags: 
+        Environment: !Sub ${Environment}
+        Owner: !Sub ${Owner} 
+
+  BatchJobQueueWorkflow:
+    Type: AWS::Batch::JobQueue
+    Properties:
+      JobQueueName: !Sub ${Environment}-workflow
+      Priority: 1
+      State: ENABLED
+      ComputeEnvironmentOrder:
+        - Order: 0
+          ComputeEnvironment: !Ref ComputeEnvironmentWorkflow
+      Tags: 
+        Environment: !Sub ${Environment}
+        Owner: !Sub ${Owner} 
+        WorkflowEngineRoleArn: !GetAtt IAMRoleWorkflow.Arn
+        DefaultTaskQueue: !Sub ${Environment}-task
+        DefaultFsap: !Ref AccessPoint
+
+#######################
+# Outputs
+#######################
 Outputs:
   VpcId:
     Value: !Ref VPC
+    Description: Virtual Private CLoud (VPC)  ID
   PublicSubNetIds:
     Value: !Sub ${SubnetPublic0},${SubnetPublic1},${SubnetPublic0}
+    Description: Public subnet for each availability zone
   InternetGatewayId:
     Value: !Ref InternetGateway
+    Description: Internet Gateway ID
   SecurityGroupId:
-    Value: !Sub ${SecurityGroup}
+    Value: !Ref SecurityGroup
+    Description: Security group for compute resources and EFS
   EfsId:
     Value: !Ref SharedDataFileSystem
-    Description: EFS ID
+    Description: EFS file system ID
+  FsapId:
+    Value: !Ref AccessPoint
+    Description: EFS access point ID

--- a/cfn-miniwdl.yaml
+++ b/cfn-miniwdl.yaml
@@ -12,12 +12,12 @@ Parameters:
   Environment:
     Description: Environment tag applied to all resources, and used in some resource names
     Type: String
-    Default: phenowdl
+    Default: miniwdl
 
   S3UploadBucket:
     Description: S3 bucket name for automatic upload of workflow outputs with `miniwdl-aws-submit --s3upload`
     Type: String
-    Default: phenowdl-bucket
+    Default:  miniwdl-bucket
     AllowedPattern: "((?=^.{3,63}$)(?!^(\\d+\\.)+\\d+$)(^(([a-z0-9]|[a-z0-9][a-z0-9\\-]*[a-z0-9])\\.)*([a-z0-9]|[a-z0-9][a-z0-9\\-]*[a-z0-9])$)|(^.{0}$))"
     ConstraintDescription: "Must respect AWS naming conventions"
 
@@ -34,12 +34,12 @@ Parameters:
   BatchSpotBidPercentage:
     Type: Number
     Description: The maximum percentage that an EC2 Spot Instance price can be when compared with the On-Demand price for that instance type before instances are launched.
-    Default: 100
+    Default: 75
 
 Resources:
 #######################
 # Networking
-# borrowing from https://github.com/awslabs/genomics-secondary-analysis-using-aws-step-functions-and-aws-batch
+# borrowed from https://github.com/awslabs/genomics-secondary-analysis-using-aws-step-functions-and-aws-batch
 #######################
   VPC:
     Type: AWS::EC2::VPC
@@ -73,13 +73,13 @@ Resources:
       VpcId: !Ref VPC
       InternetGatewayId: !Ref InternetGateway
 
-# For simplicity, one public subnet per availability zone. Private subnet(s) with NAT could work.
+# For simplicity, one public subnet per availability zone. 
   SubnetPublic0:
     Type: AWS::EC2::Subnet
     Properties:
       VpcId: !Ref VPC
-      CidrBlock: !Select [ 0, !Cidr [ !GetAtt VPC.CidrBlock, 3, 13]]
-      #MapPublicIpOnLaunch: true
+      CidrBlock: !Select [ 0, !Cidr [ !GetAtt VPC.CidrBlock, 3, 12]]
+      MapPublicIpOnLaunch: true
       AvailabilityZone:
         Fn::Select:
           - 0
@@ -96,8 +96,8 @@ Resources:
     Type: AWS::EC2::Subnet
     Properties:
       VpcId: !Ref VPC
-      CidrBlock: !Select [ 1, !Cidr [ !GetAtt VPC.CidrBlock, 3, 13]]
-      #MapPublicIpOnLaunch: true
+      CidrBlock: !Select [ 1, !Cidr [ !GetAtt VPC.CidrBlock, 3, 12]]
+      MapPublicIpOnLaunch: true
       AvailabilityZone:
         Fn::Select:
           - 1
@@ -114,8 +114,8 @@ Resources:
     Type: AWS::EC2::Subnet
     Properties:
       VpcId: !Ref VPC
-      CidrBlock: !Select [ 2, !Cidr [ !GetAtt VPC.CidrBlock, 3, 13]]
-      #MapPublicIpOnLaunch: true
+      CidrBlock: !Select [ 2, !Cidr [ !GetAtt VPC.CidrBlock, 3,12]]
+      MapPublicIpOnLaunch: true
       AvailabilityZone:
         Fn::Select:
           - 2
@@ -163,27 +163,29 @@ Resources:
       RouteTableId: !Ref PublicRouteTable
       SubnetId: !Ref SubnetPublic2
 
-  # Use a VPC Gateway Endpoint for S3 so that requests for data do not route over the public internet
-  S3VpcEndpoint:
-    Type: "AWS::EC2::VPCEndpoint"
-    Properties:
-      RouteTableIds:
-        - !Ref PublicRouteTable
-      ServiceName: !Sub com.amazonaws.${AWS::Region}.s3 #required
-      VpcId: !Ref VPC #required
 
 # Umbrella security group for Batch compute environments & EFS mount targets, allowing any traffic
-# within the VPC and outbound (but not inbound) Internet. The ingress could be locked down to only
+# within the VPC and outbound (but not inbound) Internet. 
+# ToDo: The ingress could be locked down to only
 # make the EFS mount targets (TCP 2049) reachable from the Batch compute environments.
   SecurityGroup:
     Type: AWS::EC2::SecurityGroup
     Properties:
       GroupDescription: Security group for AWS Batch Launched Instances.
+      GroupName: !Sub ${Environment}
       VpcId: !Ref VPC
+      SecurityGroupIngress:
+        - IpProtocol: "-1"
+          CidrIp: !GetAtt VPC.CidrBlock
       SecurityGroupEgress:
         - Description: Allow all outbound traffic for updates.
           IpProtocol: "-1"
           CidrIp: 0.0.0.0/0
+      Tags:
+        - Key: Environment
+          Value: !Sub ${Environment}
+        - Key: Owner
+          Value: !Sub ${Owner}
     Metadata:
       cfn_nag:
         rules_to_suppress:
@@ -193,21 +195,7 @@ Resources:
             reason: Allow all outbound traffic for updates.
           - id: W42
             reason: Allow self-ingress on all ports for inter-node communication
-  
-  # this ingress rule is needed if you have tightly coupled multi-node workloads
-  # or if you are using a parallel filesystem
-  SecurityGroupSelfIngress:
-    Type: "AWS::EC2::SecurityGroupIngress"
-    Properties:
-      Description: Allow instances in the same security group to communicate
-      IpProtocol: "-1" #required
-      GroupId: !Ref SecurityGroup
-      SourceSecurityGroupId: !Ref SecurityGroup
-    Metadata:
-      cfn_nag:
-        rules_to_suppress:
-          - id: W42
-            reason: Allow self-ingress on all ports for inter-node communication
+
 #######################
 # EFS
 # borrowed from https://github.com/aws-samples/aws-genomics-workflows
@@ -289,7 +277,7 @@ Resources:
 # For Batch Fargate tasks running miniwdl itself
 # This role needs to be set with the Batch job definition, not as part of the compute environment;
 # miniwdl-aws-submit detects it from the WorkflowEngineRoleArn tag on the workflow job queue, set
-# above.
+# below.
   IAMRoleWorkflow:
     Type: "AWS::IAM::Role"
     Properties:
@@ -541,9 +529,11 @@ Resources:
       Tags: 
         Environment: !Sub ${Environment}
         Owner: !Sub ${Owner} 
+        # those tags below are used by miniwdl_aws_submit and other utily scripts
         WorkflowEngineRoleArn: !GetAtt IAMRoleWorkflow.Arn
         DefaultTaskQueue: !Sub ${Environment}-task
         DefaultFsap: !Ref AccessPoint
+        DefaultFs: !Ref SharedDataFileSystem
 
 #######################
 # Outputs

--- a/test/build_test_image.sh
+++ b/test/build_test_image.sh
@@ -12,7 +12,7 @@ cd "$(dirname "$0")/.."
 
 # login to ECR
 AWS_REGION="$(aws configure get region)"
-ECR_REGISTRY_ID="$(aws ecr describe-registry | jq -r .registryId)"
+ECR_REGISTRY_ID="$(aws ecr describe-registry --query "registryId" --output text)"
 ECR_REPO="${ECR_REGISTRY_ID}.dkr.ecr.${AWS_REGION}.amazonaws.com/miniwdl-aws"
 aws ecr get-login-password --region $(aws configure get region) \
     | >&2 docker login --username AWS --password-stdin $ECR_REPO

--- a/test/run_tests.sh
+++ b/test/run_tests.sh
@@ -11,7 +11,7 @@ if [[ -z ${MINIWDL__AWS__WORKFLOW_IMAGE:-} ]]; then
         exit 1
     fi
 fi
-export MINIWDL_AWS_TEST_BUCKET="miniwdl-test-$(aws sts get-caller-identity | jq -r .Account)"
+export MINIWDL_AWS_TEST_BUCKET="miniwdl-test-$(aws sts get-caller-identity --query "Account" --output text)"
 >&2 echo "Creating S3 bucket $MINIWDL_AWS_TEST_BUCKET (BucketAlreadyOwnedByYou error is OK):"
 aws s3api create-bucket --bucket "$MINIWDL_AWS_TEST_BUCKET" \
     --region "$AWS_DEFAULT_REGION" --create-bucket-configuration LocationConstraint="$AWS_DEFAULT_REGION" \


### PR DESCRIPTION
1.) Replace  [miniwdl-aws-terraform](https://github.com/miniwdl-ext/miniwdl-aws-terraform) with CloudFormation template. IMHO, CloudFormation deployment is faster and cleaner. Also requires less external dependencies (TerraForm),natively supported by  AWS and supports rollback.
2.) Replace JQ output queuing with AWSCLI v2 options 