### PR TITLE
status reporting  utility

### DIFF
--- a/miniwdl_aws/__init__.py
+++ b/miniwdl_aws/__init__.py
@@ -1,3 +1,4 @@
 from .batch_job import BatchJob  # noqa: F401
 from .cli_run_s3upload import miniwdl_run_s3upload  # noqa: F401
 from .cli_submit import miniwdl_submit_awsbatch  # noqa: F401
+from .cli_status import miniwdl_aws_status  # noqa: F401

--- a/miniwdl_aws/cli_status.py
+++ b/miniwdl_aws/cli_status.py
@@ -1,0 +1,393 @@
+"""
+miniwdl-aws-status CLI entry point (console script) to report status of jobs submited to
+miniwdl "workflow job" to an AWS Batch queue with miniwdl-aws-submit CLI.
+"""
+import sys
+import os
+import argparse
+from datetime import datetime
+import boto3
+from botocore.exceptions import ClientError
+from miniwdl_aws._util import detect_aws_region
+
+DEFAULT_WORKFLOW_QUEUE = "miniwdl-workflow"
+
+
+def miniwdl_aws_status(argv=sys.argv):
+
+    # Configure from arguments/environment/tags
+    args, unused_args = parse_args(argv)
+    detect_env_args(args)
+    if args.debug:
+        print("Workflow job queue: " + args.workflow_queue, file=sys.stderr)
+
+    aws_region_name = detect_aws_region(None)
+    if not aws_region_name:
+        print(
+            "Failed to detect AWS region; configure AWS CLI or set environment AWS_DEFAULT_REGION",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+    aws_batch = boto3.client("batch", region_name=aws_region_name)
+    aws_logs = boto3.client("logs", region_name=aws_region_name)
+    detect_tags_args(aws_batch, args)
+
+    if args.command == "all":
+        # print top level status of all submited tasks
+        queue_status(aws_batch, args)
+    elif args.command == "job":
+        # status   for a specific workflow job
+        job_status(aws_batch, aws_logs, args)
+    elif args.command == "log":
+        # log for a specific workflow job
+        job_log(aws_batch, aws_logs, args)
+
+    return 0
+
+
+def parse_args(argv):
+
+    parser = argparse.ArgumentParser(
+        prog="miniwdl-aws-status",
+        description="report status of miniwdl jobs submited to AWS Batch with miiwdl-aws-submit",
+        usage="miniwdl-aws-status [optional_arguments]",
+        allow_abbrev=False,
+    )
+
+    parser.add_argument(
+        "command",
+        nargs="?",  # to make it optional: https://stackoverflow.com/questions/4480075/argparse-optional-positional-arguments
+        default="all",
+        choices=["all", "job", "log"],
+        help="type of status  to report",
+    )
+
+    parser.add_argument(
+        "--debug",
+        "-d",
+        action="store_true",
+        help="flag to generate debug information",
+    )
+
+    parser.add_argument(
+        "--exclude-debug-log",
+        action="store_true",
+        help="flag to exclude DEBUG  messages from LOG printout",
+    )
+
+    group = parser.add_argument_group("Jobs identification")
+    group.add_argument(
+        "--job-id",
+        default=None,
+        help="jobId to identify specific job. Use tha latest submited job if ommited",
+    )
+    # group.add_argument(
+    #     "--job-name",
+    #     default=None,
+    #     help="jobName to identify specific job",
+    # )
+
+    group = parser.add_argument_group("AWS Batch")
+    group.add_argument(
+        "--workflow-queue",
+        help="job queue for workflow job [env MINIWDL__AWS__WORKFLOW_QUEUE]",
+    )
+    group.add_argument(
+        "--task-queue",
+        help="job queue for task jobs [env MINIWDL__AWS__TASK_QUEUE"
+        " or detect from DefaultTaskQueue tag on workflow job queue",
+    )
+
+    args, unused_args = parser.parse_known_args(argv[1:])
+
+    return (args, unused_args)
+
+
+def detect_env_args(args):
+    """
+    Detect configuration set through environment variables (that weren't set by command-line args)
+    """
+    args.workflow_queue = (
+        args.workflow_queue
+        if args.workflow_queue
+        else os.environ.get("MINIWDL__AWS__WORKFLOW_QUEUE", DEFAULT_WORKFLOW_QUEUE)
+    )
+    if not args.workflow_queue:
+        print(
+            "--workflow-queue is required (or environment variable MINIWDL__AWS__WORKFLOW_QUEUE)",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+    args.task_queue = (
+        args.task_queue if args.task_queue else os.environ.get("MINIWDL__AWS__TASK_QUEUE", None)
+    )
+
+
+def detect_tags_args(aws_batch, args):
+    """
+    If not otherwise set by command line arguments or environment, inspect tags of the workflow job
+    queue to detect default EFS Access Point ID (fsap-xxx), task job queue, and/or workflow role
+    ARN. Infra provisioning (CloudFormation, Terraform, etc.) may have set the respective tags.
+    """
+    if not (args.task_queue):
+        workflow_queue_tags = aws_batch.describe_job_queues(jobQueues=[args.workflow_queue])[
+            "jobQueues"
+        ][0]["tags"]
+
+        if not args.task_queue:
+            args.task_queue = workflow_queue_tags.get("DefaultTaskQueue", None)
+            if not args.task_queue:
+                print(
+                    "Unable to detect default task job queue name from DefaultTaskQueue tag of workflow job queue."
+                    " Set --task-queue or environment variable MINIWDL__AWS__TASK_QUEUE.",
+                    file=sys.stderr,
+                )
+                sys.exit(1)
+
+
+def get_jobs(aws_batch, queue, status):
+    try:
+        job_paginator = aws_batch.get_paginator("list_jobs")
+        job_page_iterator = job_paginator.paginate(jobQueue=queue, jobStatus=status)
+    except ClientError as exe:
+        print("Unable to get jobs list: %s", str(exe), file=sys.stderr)
+        sys.exit(1)
+
+    result = list()
+    for page in job_page_iterator:
+        result += page["jobSummaryList"]
+
+    job_list = list()
+    for item in result:
+        job_list.append(
+            {
+                "jobId": item["jobId"],
+                "jobName": item["jobName"],
+                "status": item["status"],
+                "statusReason": item["statusReason"] if "statusReason" in item else None,
+                "createdAt": item["createdAt"] if "createdAt" in item else None,
+                "stoppedAt": item["stoppedAt"] if "stoppedAt" in item else None,
+            }
+        )
+
+    return job_list
+
+
+def print_jobs(jobs):
+    for job in jobs:
+        start_time_str = (
+            datetime.utcfromtimestamp(job["createdAt"] / 1000).strftime("%Y-%m-%d %H:%M:%S")
+            if job["createdAt"]
+            else "----"
+        )
+        stop_time_str = (
+            datetime.utcfromtimestamp(job["stoppedAt"] / 1000).strftime("%Y-%m-%d %H:%M:%S")
+            if job["stoppedAt"]
+            else "----"
+        )
+        print(
+            f"{job['jobId']}\t{job['status']:<12}\t{start_time_str:<20}\t{stop_time_str:<20}"
+            f"\t{job['jobName']}"
+        )
+
+
+def queue_status(aws_batch, args):
+    # get list of all runnig jobs
+    # aws batch list-jobs --job-queue miniwdl-workflow --job-status RUNNING
+    waiting_status = ["SUBMITTED", "PENDING", "RUNNABLE", "STARTING"]
+    active_status = ["RUNNING", "SUCCEEDED", "FAILED"]
+
+    waiting_jobs = []
+    active_jobs = []
+
+    for status in waiting_status:
+        jobs = get_jobs(aws_batch, args.workflow_queue, status)
+        waiting_jobs += jobs
+    # sort the  list in descdending order of creation date
+    if len(waiting_jobs) > 0:
+        waiting_jobs = sorted(waiting_jobs, reverse=True, key=lambda d: d["createdAt"])
+        print("WAITING jobs:")
+        print_jobs(waiting_jobs)
+
+    for status in active_status:
+        jobs = get_jobs(aws_batch, args.workflow_queue, status)
+        active_jobs += jobs
+    # sort the  list in descdending order of creation date
+    if len(active_jobs) > 0:
+        active_jobs = sorted(active_jobs, reverse=True, key=lambda d: d["createdAt"])
+        print("ACTIVE jobs:")
+        print_jobs(active_jobs)
+
+
+def get_latest_job(aws_batch, args):
+    """return ID of teh latest submited job"""
+    all_status = ["SUBMITTED", "PENDING", "RUNNABLE", "STARTING", "RUNNING", "SUCCEEDED", "FAILED"]
+    all_jobs = []
+    for status in all_status:
+        jobs = get_jobs(aws_batch, args.workflow_queue, status)
+        all_jobs += jobs
+
+    if len(all_jobs) == 0:
+        return None
+
+    all_jobs = sorted(all_jobs, reverse=True, key=lambda d: d["createdAt"])
+    return all_jobs[0]["jobId"]
+
+
+def job_status(aws_batch, aws_logs, args):
+
+    if not args.job_id:
+        print(
+            "[WARNING] No --job-id parameter specified, use the latest submited job",
+            file=sys.stderr,
+        )
+        args.job_id = get_latest_job(aws_batch, args)
+
+    # get job  description
+    job_description = aws_batch.describe_jobs(jobs=[args.job_id])
+    if "jobs" not in job_description:
+        print(f"can't find job  description for {args.job_id}", file=sys.stderr)
+        sys.exit(1)
+
+    job = job_description["jobs"][0]
+    # print job  description
+    print(f"jobId       : {job['jobId']}")
+    print(f"jobName     : {job['jobName']}")
+    print(f"status      : {job['status']}")
+    if "statusReason" in job:
+        print(f"statusReason: {job['statusReason']}")
+    if "createdAt" in job:
+        print(
+            f"createdAt   : {datetime.utcfromtimestamp(job['createdAt']/1000).strftime('%Y-%m-%d %H:%M:%S')}"
+        )
+    if "startedAt" in job:
+        print(
+            f"statrteAt   : {datetime.utcfromtimestamp(job['startedAt']/1000).strftime('%Y-%m-%d %H:%M:%S')}"
+        )
+    if "stoppedAt" in job:
+        print(
+            f"stoppedAt   : {datetime.utcfromtimestamp(job['stoppedAt']/1000).strftime('%Y-%m-%d %H:%M:%S')}"
+        )
+
+    container = job["container"]
+
+    command = container["command"]
+    cli = " ".join(command)
+    print(f"command     : {cli}")
+
+    if "logStreamName" not in container:
+        return  # log not ready yet , we did  all we  can until now...
+    logStreamName = container["logStreamName"]
+    print(f"logStream   : {logStreamName}")
+
+    # extract  sub-tasks IDs from logs
+    task_id = []
+    try:
+        logs = get_log(aws_logs, logStreamName)
+    except:
+        return  # log not ready yet , we did  all we  can until now...
+
+    for item in logs:
+        message = item["message"]
+        if ("AWS Batch job submitted" in message) or ("AWS Batch job change" in message):
+            substring_after = message.split("jobId:", 1)[1]
+            jobId = substring_after.split('"', 2)[1]
+            task_id.append(jobId)
+    # print list of subtask
+    if len(task_id) > 0:
+        task_id = list(set(task_id))  # eliminate  dublicates
+        print(f"Sub-tasks   : {len(task_id)}")
+        task_description = aws_batch.describe_jobs(jobs=task_id)
+        if "jobs" not in job_description:
+            print(f"can't find job  description for {task_id}", file=sys.stderr)
+            sys.exit(1)
+
+        tasks = task_description["jobs"]
+        for task in tasks:
+            start_time_str = (
+                datetime.utcfromtimestamp(task["createdAt"] / 1000).strftime("%Y-%m-%d %H:%M:%S")
+                if "createdAt" in task
+                else "----"
+            )
+            stop_time_str = (
+                datetime.utcfromtimestamp(task["stoppedAt"] / 1000).strftime("%Y-%m-%d %H:%M:%S")
+                if "stoppedAt" in task
+                else "----"
+            )
+            print(
+                f"{task['jobId']}\t{task['status']}\t{start_time_str}\t{stop_time_str}"
+                f"\t{task['jobName']}"
+            )
+
+
+def get_log(aws_logs, logStreamName):
+    # try:
+    #     job_paginator = aws_logs.get_paginator('get_log_events')
+    #     job_page_iterator = job_paginator.paginate(
+    #             logGroupName='/aws/batch/job',logStreamName=logStreamName,startFromHead=True
+    #             )
+    # except ClientError as exe:
+    #     print('Unable to get log  events: %s', str(exe),file=sys.stderr)
+    #     sys.exit(1)
+
+    # result = list()
+    # for page in job_page_iterator:
+    #     result += page['events']
+
+    have_more = True
+    nextToken = None
+
+    results = []
+
+    while have_more:
+        if not nextToken:
+            logs = aws_logs.get_log_events(
+                logGroupName="/aws/batch/job", logStreamName=logStreamName, startFromHead=True
+            )
+        else:
+            logs = aws_logs.get_log_events(
+                logGroupName="/aws/batch/job",
+                logStreamName=logStreamName,
+                startFromHead=True,
+                nextToken=nextToken,
+            )
+
+        results += logs["events"]
+
+        if ("nextForwardToken" in logs) and (nextToken != logs["nextForwardToken"]):
+            nextToken = logs["nextForwardToken"]
+        else:
+            have_more = False
+
+    return results
+
+
+def job_log(aws_batch, aws_logs, args):
+    """print log associated with this task"""
+    if not args.job_id:
+        print(
+            "[WARNING] No --job-id parameter specified, use the latest submited job",
+            file=sys.stderr,
+        )
+        args.job_id = get_latest_job(aws_batch, args)
+
+    # get job  description
+    job_description = aws_batch.describe_jobs(jobs=[args.job_id])
+    if "jobs" not in job_description:
+        print(f"can't find job  description for {args.job_id}", file=sys.stderr)
+        sys.exit(1)
+    job = job_description["jobs"][0]
+    container = job["container"]
+    logStreamName = container["logStreamName"]
+
+    print(f"LOG FOR JOB {job['jobId']} ({job['jobName']}) ")
+    logs = get_log(aws_logs, logStreamName)
+    for item in logs:
+        message = item["message"]
+        if args.exclude_debug_log and (" DEBUG " in message[:80]):
+            continue
+        print(message)
+
+
+if __name__ == "__main__":
+    sys.exit(miniwdl_aws_status())

--- a/setup.py
+++ b/setup.py
@@ -20,6 +20,7 @@ setup(
         "miniwdl.plugin.container_backend": ["aws_batch_job = miniwdl_aws:BatchJob"],
         "console_scripts": [
             "miniwdl-run-s3upload = miniwdl_aws:miniwdl_run_s3upload",
+            "miniwdl-aws-status = miniwdl_aws:miniwdl_aws_status",
             "miniwdl-aws-submit = miniwdl_aws.__main__:main",
         ],
     },


### PR DESCRIPTION
A small but useful add-on for miniwdl-aws package - a small utility to print out essential job information . Hope it is self explanatory:
```
$miniwdl-aws-status
ACTIVE jobs:
22eadbfd-1150-40a7-bb1c-2533b8fab671    SUCCEEDED       2022-08-19 13:51:17     2022-08-19 13:59:52     miniwdl_run_assemble_refbased-mstmx5vl
c7c83bba-5e39-423a-8276-e25c114b8f8f    FAILED          2022-08-19 13:48:49     2022-08-19 13:49:50     miniwdl_run_assemble_refbased-f3hhv6ib
b15c99d7-a60d-4900-b6aa-21478128351a    SUCCEEDED       2022-08-19 13:40:51     2022-08-19 13:43:16     miniwdl_run_assemble_refbased-ng4dfe74
```

```
$miniwdl-aws-status job
[WARNING] No --job-id parameter specified, use the latest submited job
jobId       : 22eadbfd-1150-40a7-bb1c-2533b8fab671
jobName     : miniwdl_run_assemble_refbased-mstmx5vl
status      : SUCCEEDED
statusReason: Essential container in task exited
createdAt   : 2022-08-19 13:51:17
statrteAt   : 2022-08-19 13:52:19
stoppedAt   : 2022-08-19 13:59:52
command     : miniwdl-run-s3upload https://github.com/broadinstitute/viral-pipelines/raw/v2.1.28.0/pipes/WDL/workflows/assemble_refbased.wdl reads_unmapped_bams=https://github.com/broadinstitute/viral-pipelines/raw/v2.1.19.0/test/input/G5012.3.testreads.bam reference_fasta=https://github.com/broadinstitute/viral-pipelines/raw/v2.1.19.0/test/input/ebov-makona.fasta sample_name=G5012.3 --no-cache --dir /mnt/efs/miniwdl_run --s3upload s3://miniwdl-bucket/assemblies/
logStream   : miniwdl_run_assemble_refbased-mstmx5vl/default/0592cde3b93b46fca1e458422c5ff55f
Sub-tasks   : 12
60e6f575-e6c7-4bda-b537-5d6d4b462d3c    SUCCEEDED       2022-08-19 13:56:21     2022-08-19 13:57:55     plot_ref_coverage-6hinjoje
13266465-f5cc-4b76-ac9c-5e8e45edf7d1    SUCCEEDED       2022-08-19 13:54:10     2022-08-19 13:55:26     align_to_ref-0-5srk4ibw
f51eb69b-241c-407b-a751-53502ca06691    SUCCEEDED       2022-08-19 13:57:08     2022-08-19 13:59:00     align_to_self-0-6pg4c6ki
4ae8411b-4fa2-403a-b523-4484ba703b90    SUCCEEDED       2022-08-19 13:56:17     2022-08-19 13:57:06     call_consensus-lmad3d2j
```

```
$ miniwdl-aws-status log
[WARNING] No --job-id parameter specified, use the latest submited job
LOG FOR JOB 22eadbfd-1150-40a7-bb1c-2533b8fab671 (miniwdl_run_assemble_refbased-mstmx5vl) 
upload: tmp/tmp29kmbb5q/.test.miniwdl-run-s3upload to s3://miniwdl-bucket/assemblies/.test.miniwdl-run-s3upload
2022-08-19 13:52:22.436 wdl.w:assemble_refbased NOTICE workflow start :: name: "assemble_refbased", source: 
```

```
$ miniwdl-aws-status log --job-id f35e0439-53c1-4922-ab94-74fa831a2ede 
LOG FOR JOB f35e0439-53c1-4922-ab94-74fa831a2ede (download-aria2c-5knkryek) 
+ mkdir __out
+ cd __out
+ aria2c -x 10 -s 10 --file-allocation=none --retry-wait=2 --stderr=true --enable-color=false https://github.com/broadinstitute/viral-pipelines/raw/v2.1.19.0/test/input/G5012.3.testreads.bam
08/19 13:54:08 [NOTICE] Downloading 1 item(s)
08/19 13:54:08 [NOTICE] CUID#7 - Redirecting to https://raw.githubusercontent.com/broadinstitute/viral-pipelines/v2.1.19.0/test/input/G5012.3.testreads.bam
08/19 13:54:08 [NOTICE] Download complete: /mnt/efs/miniwdl_run/20220819_135222_assemble_refbased/download/0/work/__out/G5012.3.testreads.bam
Download Results:
gid   |stat|avg speed  |path/URI
======+====+===========+=======================================================
d61e48|OK  |    14MiB/s|/mnt/efs/miniwdl_run/20220819_135222_assemble_refbased/download/0/work/__out/G5012.3.testreads.bam
Status Legend:
(OK):download completed.
```