### PR TITLE
multi-GPU tasks

### DIFF
--- a/miniwdl_aws.cfg
+++ b/miniwdl_aws.cfg
@@ -74,3 +74,6 @@ retry_wait = 20
 # Explicitly `sync` files in the task working directory before exiting task container. Requires
 # `find`, `xargs`, and `sync` commands available in the container image.
 container_sync = false
+# When task runtime includes "gpu: true", request this many GPUs from AWS Batch. (The WDL spec
+# defines runtime.gpu as a Boolean, as of this writing.)
+gpu_value = 1

--- a/miniwdl_aws/batch_job.py
+++ b/miniwdl_aws/batch_job.py
@@ -263,7 +263,10 @@ class BatchJobBase(WDL.runtime.task_container.TaskContainer):
         ]
 
         if self.runtime_values.get("gpu", False):
-            resource_requirements += [{"type": "GPU", "value": "1"}]
+            gpu_value = 1
+            if self.cfg.has_option("aws", "gpu_value"):
+                gpu_value = self.cfg.get_int("aws", "gpu_value")
+            resource_requirements += [{"type": "GPU", "value": str(gpu_value)}]
 
         container_properties = {
             "image": image_tag,

--- a/miniwdl_aws/batch_job.py
+++ b/miniwdl_aws/batch_job.py
@@ -266,6 +266,8 @@ class BatchJobBase(WDL.runtime.task_container.TaskContainer):
             gpu_value = 1
             if self.cfg.has_option("aws", "gpu_value"):
                 gpu_value = self.cfg.get_int("aws", "gpu_value")
+            if gpu_value > 1:
+                logger.info(_("requesting multiple GPUs", value=gpu_value))
             resource_requirements += [{"type": "GPU", "value": str(gpu_value)}]
 
         container_properties = {


### PR DESCRIPTION
Add a new config option allowing tasks to use multiple GPUs. Since the WDL spec defines `runtime.gpu` as a Boolean only, the new config option `[aws] gpu_value` defines the number of GPUs to request for any task setting `runtime.gpu` to `true`.