### PR TITLE
configurable container properties

### DIFF
--- a/miniwdl_aws.cfg
+++ b/miniwdl_aws.cfg
@@ -77,3 +77,9 @@ container_sync = false
 # When task runtime includes "gpu: true", request this many GPUs from AWS Batch. (The WDL spec
 # defines runtime.gpu as a Boolean, as of this writing.)
 gpu_value = 1
+# ContainerProperties fields to set on AWS Batch jobs for tasks, OTHER than the following which are
+# set by miniwdl-aws, task runtime{}, or other available config options:
+#     image command environment resourceRequirements mountPoints privileged
+# see: https://docs.aws.amazon.com/batch/latest/APIReference/API_ContainerProperties.html
+container_properties = {
+    }

--- a/miniwdl_aws/batch_job.py
+++ b/miniwdl_aws/batch_job.py
@@ -265,7 +265,9 @@ class BatchJobBase(WDL.runtime.task_container.TaskContainer):
         if self.runtime_values.get("gpu", False):
             gpu_value = self.cfg.get_int("aws", "gpu_value", 1)
             if gpu_value > 1:
-                logger.info(_("requesting multiple GPUs", value=gpu_value))
+                logger.info(
+                    _("requesting multiple GPUs (per config [aws] gpu_value)", gpu_value=gpu_value)
+                )
             resource_requirements += [{"type": "GPU", "value": str(gpu_value)}]
 
         container_properties = {

--- a/miniwdl_aws/batch_job.py
+++ b/miniwdl_aws/batch_job.py
@@ -282,7 +282,7 @@ class BatchJobBase(WDL.runtime.task_container.TaskContainer):
             "mountPoints": [{"containerPath": self._fs_mount, "sourceVolume": "file_io_root"}],
         }
 
-        for k, v in self.cfg.get_dict("aws", "container_properties", {}):
+        for k, v in self.cfg.get_dict("aws", "container_properties", {}).items():
             if k in container_properties:
                 raise WDL.Error.RuntimeError(
                     f"Config [aws] container_properties may not override '{k}'"

--- a/miniwdl_aws/batch_job.py
+++ b/miniwdl_aws/batch_job.py
@@ -263,9 +263,7 @@ class BatchJobBase(WDL.runtime.task_container.TaskContainer):
         ]
 
         if self.runtime_values.get("gpu", False):
-            gpu_value = 1
-            if self.cfg.has_option("aws", "gpu_value"):
-                gpu_value = self.cfg.get_int("aws", "gpu_value")
+            gpu_value = self.cfg.get_int("aws", "gpu_value", 1)
             if gpu_value > 1:
                 logger.info(_("requesting multiple GPUs", value=gpu_value))
             resource_requirements += [{"type": "GPU", "value": str(gpu_value)}]
@@ -281,6 +279,13 @@ class BatchJobBase(WDL.runtime.task_container.TaskContainer):
             "privileged": self.runtime_values.get("privileged", False),
             "mountPoints": [{"containerPath": self._fs_mount, "sourceVolume": "file_io_root"}],
         }
+
+        for k, v in self.cfg.get_dict("aws", "container_properties", {}):
+            if k in container_properties:
+                raise WDL.Error.RuntimeError(
+                    f"Config [aws] container_properties may not override '{k}'"
+                )
+            container_properties[k] = v
 
         if self.cfg["task_runtime"].get_bool("as_user"):
             user = f"{os.geteuid()}:{os.getegid()}"


### PR DESCRIPTION
Add a config option with a dict to set additional ContainerProperties (that aren't already set by miniwdl-aws itself). Useful to adjust exotic settings like ulimits, sharedMemorySize, etc.