### PR TITLE
add config option to adjust AWS Batch job memory requirements

### DIFF
--- a/miniwdl_aws.cfg
+++ b/miniwdl_aws.cfg
@@ -83,3 +83,9 @@ gpu_value = 1
 # see: https://docs.aws.amazon.com/batch/latest/APIReference/API_ContainerProperties.html
 container_properties = {
     }
+# Add this many mebibytes (MiB) to each task's runtime.memory setting when filling out the
+# memory requirement for each AWS Batch job. The default is meant to offset the memory that AWS
+# Batch itself reserves on each worker instance; without this, if runtime.memory is e.g. "8 GiB"
+# then AWS Batch might use larger-than-necessary worker instances and pack them inefficiently.
+# see: https://docs.aws.amazon.com/batch/latest/userguide/memory-management.html
+memory_delta = -33

--- a/miniwdl_aws/batch_job.py
+++ b/miniwdl_aws/batch_job.py
@@ -244,7 +244,11 @@ class BatchJobBase(WDL.runtime.task_container.TaskContainer):
         image_tag = self.runtime_values.get("docker", "ubuntu:20.04")
         vcpu = self.runtime_values.get("cpu", 1)
         memory_mbytes = max(
-            math.ceil(self.runtime_values.get("memory_reservation", 0) / 1048576), 1024
+            (
+                math.ceil(self.runtime_values.get("memory_reservation", 0) / 1048576)
+                + self.cfg.get_int("aws", "memory_delta", -33)
+            ),
+            991,
         )
         commands = [
             f"cd {self.container_dir}/work",


### PR DESCRIPTION
Add config [aws] memory_delta to adjust the job memory requested from AWS Batch relative to the task runtime.memory. This may help to ensure right-sized worker instances by offsetting small amounts of memory that Batch itself reserves.

#16
